### PR TITLE
Feature memory write

### DIFF
--- a/include/ktx.h
+++ b/include/ktx.h
@@ -364,7 +364,7 @@ ktxWriteKTXN(const char* dstname, const KTX_texture_info* imageInfo,
  * Writes a KTX file using supplied data into memory.
  */
 KTX_error_code
-ktxWriteKTXM(const void **bytes, GLsizei *size, const KTX_texture_info* textureInfo,
+ktxWriteKTXM(unsigned char** bytes, GLsizei* size, const KTX_texture_info* textureInfo,
                          GLsizei bytesOfKeyValueData, const void* keyValueData,
                          GLuint numImages, KTX_image_info images[]);
 

--- a/include/ktx.h
+++ b/include/ktx.h
@@ -104,7 +104,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  * @mainpage The KTX Library
  *
  * @section intro_sec Introduction
- * 
+ *
  * libktx is a small library of functions for creating KTX (Khronos
  * TeXture) files and instantiating OpenGL&reg; and OpenGL&reg; ES
  * textures from them.
@@ -252,7 +252,7 @@ typedef struct KTX_texture_info_t
 	 * For non-compressed textures, should be the same as glFormat.
 	 * For compressed textures specifies the base internal, e.g.
 	 * GL_RGB, GL_RGBA.
-     */                        
+     */
 	khronos_uint32_t glBaseInternalFormat;
 	/** @brief Width of the image for texture level 0, in pixels. */
 	khronos_uint32_t pixelWidth;
@@ -342,7 +342,7 @@ ktxLoadTextureM(const void* bytes, GLsizei size, GLuint* pTexture, GLenum* pTarg
 				unsigned int* pKvdLen, unsigned char** ppKvd);
 
 /* ktxWriteKTXF
- * 
+ *
  * Writes a KTX file using supplied data.
  */
 KTX_error_code
@@ -351,7 +351,7 @@ ktxWriteKTXF(FILE*, const KTX_texture_info* imageInfo,
 			 GLuint numImages, KTX_image_info images[]);
 
 /* ktxWriteKTXN
- * 
+ *
  * Writes a KTX file using supplied data.
  */
 KTX_error_code
@@ -365,8 +365,8 @@ ktxWriteKTXN(const char* dstname, const KTX_texture_info* imageInfo,
  */
 KTX_error_code
 ktxWriteKTXM(unsigned char** bytes, GLsizei* size, const KTX_texture_info* textureInfo,
-                         GLsizei bytesOfKeyValueData, const void* keyValueData,
-                         GLuint numImages, KTX_image_info images[]);
+			 GLsizei bytesOfKeyValueData, const void* keyValueData,
+			 GLuint numImages, KTX_image_info images[]);
 
 /* ktxErrorString()
  *

--- a/include/ktx.h
+++ b/include/ktx.h
@@ -359,6 +359,15 @@ ktxWriteKTXN(const char* dstname, const KTX_texture_info* imageInfo,
 			 GLsizei bytesOfKeyValueData, const void* keyValueData,
 			 GLuint numImages, KTX_image_info images[]);
 
+/* ktxWriteKTXM
+ *
+ * Writes a KTX file using supplied data into memory.
+ */
+KTX_error_code
+ktxWriteKTXM(const void **bytes, GLsizei *size, const KTX_texture_info* textureInfo,
+                         GLsizei bytesOfKeyValueData, const void* keyValueData,
+                         GLuint numImages, KTX_image_info images[]);
+
 /* ktxErrorString()
  *
  * Returns a string corresponding to a KTX error code.

--- a/lib/hashtable.c
+++ b/lib/hashtable.c
@@ -107,6 +107,7 @@ ktxHashTable_Destroy(KTX_hash_table This)
 
     for(kv = *(key_and_value_t**)This; kv != NULL;) {
 		key_and_value_t* tmp = (key_and_value_t*)kv->hh.next;
+        HASH_DELETE(hh, /*head*/*(key_and_value_t**)This, kv);
 		free(kv);
 		kv = tmp;
     }
@@ -141,7 +142,7 @@ ktxHashTable_AddKVPair(KTX_hash_table This, const char* key, unsigned int valueL
 
 		if (keyLen == 1)
 			return KTX_INVALID_VALUE;	/* Empty string */
-	
+
 		/* Allocate all the memory as a block */
 		kv = (key_and_value_t*)malloc(sizeof(key_and_value_t) + keyLen + valueLen);
 		/* Put key first */

--- a/lib/hashtable.c
+++ b/lib/hashtable.c
@@ -82,7 +82,7 @@ typedef struct _keyAndValue {
 KTX_hash_table
 ktxHashTable_Create()
 {
-    key_and_value_t** kvt = (key_and_value_t**)malloc(sizeof (key_and_value_t**));
+	key_and_value_t** kvt = (key_and_value_t**)malloc(sizeof (key_and_value_t**));
 	*kvt = NULL;
 	return (KTX_hash_table)kvt;
 }
@@ -105,12 +105,12 @@ ktxHashTable_Destroy(KTX_hash_table This)
 {
 	key_and_value_t* kv;
 
-    for(kv = *(key_and_value_t**)This; kv != NULL;) {
+	for(kv = *(key_and_value_t**)This; kv != NULL;) {
 		key_and_value_t* tmp = (key_and_value_t*)kv->hh.next;
-        HASH_DELETE(hh, /*head*/*(key_and_value_t**)This, kv);
+		HASH_DELETE(hh, /*head*/*(key_and_value_t**)This, kv);
 		free(kv);
 		kv = tmp;
-    }
+	}
 	free(This);
 }
 

--- a/lib/ktxfilestream.c
+++ b/lib/ktxfilestream.c
@@ -49,50 +49,106 @@ MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
 #include "ktxint.h"
 #include "ktxfilestream.h"
 
+/**
+ * @internal
+ * @~English
+ * @brief Read bytes from a ktxFileStream.
+ *
+ * @param [out] dst           pointer to a block of memory with a size
+               of at least @p size bytes, converted to a void*.
+ * @param [in] size          total size of bytes to be read.
+ * @param [in] src           pointer to a FILE object, converted to a void*, that specifies an input stream.
+ *
+ * @return      KTX_SUCCESS on success, other KTX_* enum values on error.
+ *
+ * @exception KTX_INVALID_VALUE @p dst is @c NULL or @p src is @c NULL.
+ * @exception KTX_UNEXPECTED_END_OF_FILE the file does not contain the expected amount of data.
+ */
 static
-int ktxFileStream_read(void* dst, const GLsizei count, void* src)
+KTX_error_code ktxFileStream_read(void* dst, const GLsizei size, void* src)
 {
-        if (!dst || !src || (fread(dst, count, 1, (FILE*)src) != 1))
-        {
-                return 0;
-        }
+        if (!dst || !src)
+                return KTX_INVALID_VALUE;
 
-        return 1;
+        if (fread(dst, size, 1, (FILE*)src) != 1)
+                return KTX_UNEXPECTED_END_OF_FILE;
+
+        return KTX_SUCCESS;
 }
 
+/**
+ * @internal
+ * @~English
+ * @brief Skip bytes in a ktxFileStream.
+ *
+ * @param [in] count         number of bytes to be skipped.
+ * @param [in] src           pointer to a FILE object, converted to a void*, that specifies an input stream.
+ *
+ * @return      KTX_SUCCESS on success, other KTX_* enum values on error.
+ *
+ * @exception KTX_INVALID_VALUE @p dst is @c NULL or @p count is less than zero.
+ * @exception KTX_UNEXPECTED_END_OF_FILE the file does not contain the expected amount of data.
+ */
 static
-int ktxFileStream_skip(const GLsizei count, void* src)
+KTX_error_code ktxFileStream_skip(const GLsizei count, void* src)
 {
-        if (!src || (count < 0) || (fseek((FILE*)src, count, SEEK_CUR) != 0))
-        {
-                return 0;
-        }
+        if (!src || (count < 0))
+                return KTX_INVALID_VALUE;
 
-        return 1;
+        if (fseek((FILE*)src, count, SEEK_CUR) != 0)
+                return KTX_UNEXPECTED_END_OF_FILE;
+
+        return KTX_SUCCESS;
 }
 
+/**
+ * @internal
+ * @~English
+ * @brief Write bytes to a ktxFileStream.
+ *
+ * @param [in] src           pointer to the array of elements to be written, converted to a const void*.
+ * @param [in] size          size in bytes of each element to be written.
+ * @param [in] count         number of elements, each one with a @p size of size bytes.
+ * @param [out] dst          pointer to a FILE object, converted to a void*, that specifies an output stream.
+ *
+ * @return      KTX_SUCCESS on success, other KTX_* enum values on error.
+ *
+ * @exception KTX_INVALID_VALUE @p dst is @c NULL or @p src is @c NULL.
+ * @exception KTX_FILE_WRITE_ERROR a system error occurred while writing the file.
+ */
 static
-int ktxFileStream_write(const void *src, const GLsizei size, const GLsizei count, void* dst)
+KTX_error_code ktxFileStream_write(const void *src, const GLsizei size, const GLsizei count, void* dst)
 {
-        if (!dst || !src || (fwrite(src, size, count, (FILE*)dst) != count))
-        {
-                return 0;
-        }
+        if (!dst || !src)
+                return KTX_INVALID_VALUE;
 
-        return count;
+        if (fwrite(src, size, count, (FILE*)dst) != count)
+                return KTX_FILE_WRITE_ERROR;
+
+        return KTX_SUCCESS;
 }
 
-int ktxFileInit(struct ktxStream* stream, FILE* file)
+/**
+ * @internal
+ * @~English
+ * @brief Initializes a ktxFileStream.
+ *
+ * @param [in] stream
+ * @param [in] file
+ *
+ * @return      KTX_SUCCESS on success, KTX_INVALID_VALUE on error.
+ *
+ * @exception KTX_INVALID_VALUE @p stream is @c NULL or @p file is @c NULL.
+ */
+KTX_error_code ktxFileInit(struct ktxStream* stream, FILE* file)
 {
         if (!stream || !file)
-        {
-                return 0;
-        }
+                return KTX_INVALID_VALUE;
 
         stream->src = (void*)file;
         stream->read = ktxFileStream_read;
         stream->skip = ktxFileStream_skip;
         stream->write = ktxFileStream_write;
 
-        return 1;
+        return KTX_SUCCESS;
 }

--- a/lib/ktxfilestream.c
+++ b/lib/ktxfilestream.c
@@ -55,7 +55,7 @@ MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
  * @brief Read bytes from a ktxFileStream.
  *
  * @param [out] dst           pointer to a block of memory with a size
-               of at least @p size bytes, converted to a void*.
+			   of at least @p size bytes, converted to a void*.
  * @param [in] size          total size of bytes to be read.
  * @param [in] src           pointer to a FILE object, converted to a void*, that specifies an input stream.
  *
@@ -67,13 +67,13 @@ MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
 static
 KTX_error_code ktxFileStream_read(void* dst, const GLsizei size, void* src)
 {
-        if (!dst || !src)
-                return KTX_INVALID_VALUE;
+	if (!dst || !src)
+		return KTX_INVALID_VALUE;
 
-        if (fread(dst, size, 1, (FILE*)src) != 1)
-                return KTX_UNEXPECTED_END_OF_FILE;
+	if (fread(dst, size, 1, (FILE*)src) != 1)
+		return KTX_UNEXPECTED_END_OF_FILE;
 
-        return KTX_SUCCESS;
+	return KTX_SUCCESS;
 }
 
 /**
@@ -92,13 +92,13 @@ KTX_error_code ktxFileStream_read(void* dst, const GLsizei size, void* src)
 static
 KTX_error_code ktxFileStream_skip(const GLsizei count, void* src)
 {
-        if (!src || (count < 0))
-                return KTX_INVALID_VALUE;
+	if (!src || (count < 0))
+		return KTX_INVALID_VALUE;
 
-        if (fseek((FILE*)src, count, SEEK_CUR) != 0)
-                return KTX_UNEXPECTED_END_OF_FILE;
+	if (fseek((FILE*)src, count, SEEK_CUR) != 0)
+		return KTX_UNEXPECTED_END_OF_FILE;
 
-        return KTX_SUCCESS;
+	return KTX_SUCCESS;
 }
 
 /**
@@ -119,13 +119,13 @@ KTX_error_code ktxFileStream_skip(const GLsizei count, void* src)
 static
 KTX_error_code ktxFileStream_write(const void *src, const GLsizei size, const GLsizei count, void* dst)
 {
-        if (!dst || !src)
-                return KTX_INVALID_VALUE;
+	if (!dst || !src)
+		return KTX_INVALID_VALUE;
 
-        if (fwrite(src, size, count, (FILE*)dst) != count)
-                return KTX_FILE_WRITE_ERROR;
+	if (fwrite(src, size, count, (FILE*)dst) != count)
+		return KTX_FILE_WRITE_ERROR;
 
-        return KTX_SUCCESS;
+	return KTX_SUCCESS;
 }
 
 /**
@@ -142,13 +142,13 @@ KTX_error_code ktxFileStream_write(const void *src, const GLsizei size, const GL
  */
 KTX_error_code ktxFileInit(struct ktxStream* stream, FILE* file)
 {
-        if (!stream || !file)
-                return KTX_INVALID_VALUE;
+	if (!stream || !file)
+		return KTX_INVALID_VALUE;
 
-        stream->src = (void*)file;
-        stream->read = ktxFileStream_read;
-        stream->skip = ktxFileStream_skip;
-        stream->write = ktxFileStream_write;
+	stream->src = (void*)file;
+	stream->read = ktxFileStream_read;
+	stream->skip = ktxFileStream_skip;
+	stream->write = ktxFileStream_write;
 
-        return KTX_SUCCESS;
+	return KTX_SUCCESS;
 }

--- a/lib/ktxfilestream.c
+++ b/lib/ktxfilestream.c
@@ -1,0 +1,98 @@
+/* -*- tab-width: 4; -*- */
+/* vi: set sw=2 ts=4: */
+
+/**
+ * @file
+ * @~English
+ *
+ * @brief FImplementation of ktxStream for FILE.
+ *
+ * @author Maksim Kolesin, Under Development
+ * @author Georg Kolling, Imagination Technology
+ * @author Mark Callow, HI Corporation
+ */
+
+/*
+Copyright (c) 2010 The Khronos Group Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and/or associated documentation files (the
+"Materials"), to deal in the Materials without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Materials, and to
+permit persons to whom the Materials are furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be included
+unaltered in all copies or substantial portions of the Materials.
+Any additions, deletions, or changes to the original source files
+must be clearly indicated in accompanying documentation.
+
+If only executable code is distributed, then the accompanying
+documentation must state that "this software is based in part on the
+work of the Khronos Group".
+
+THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+*/
+
+#include <string.h>
+#include <stdlib.h>
+
+#include "KHR/khrplatform.h"
+#include "ktx.h"
+#include "ktxint.h"
+#include "ktxfilestream.h"
+
+static
+int ktxFileStream_read(void* dst, const GLsizei count, void* src)
+{
+        if (!dst || !src || (fread(dst, count, 1, (FILE*)src) != 1))
+        {
+                return 0;
+        }
+
+        return 1;
+}
+
+static
+int ktxFileStream_skip(const GLsizei count, void* src)
+{
+        if (!src || (count < 0) || (fseek((FILE*)src, count, SEEK_CUR) != 0))
+        {
+                return 0;
+        }
+
+        return 1;
+}
+
+static
+int ktxFileStream_write(const void *src, const GLsizei size, const GLsizei count, void* dst)
+{
+        if (!dst || !src || (fwrite(src, size, count, (FILE*)dst) != count))
+        {
+                return 0;
+        }
+
+        return count;
+}
+
+int ktxFileInit(struct ktxStream* stream, FILE* file)
+{
+        if (!stream || !file)
+        {
+                return 0;
+        }
+
+        stream->src = (void*)file;
+        stream->read = ktxFileStream_read;
+        stream->skip = ktxFileStream_skip;
+        stream->write = ktxFileStream_write;
+
+        return 1;
+}

--- a/lib/ktxfilestream.h
+++ b/lib/ktxfilestream.h
@@ -43,6 +43,9 @@ MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
 #include "ktxint.h"
 #include "ktxstream.h"
 
-int ktxFileInit(struct ktxStream* stream, FILE* file);
+/*
+ * ktxFileInit: Initialize a ktxStream to a ktxFileStream with a FILE object
+ */
+KTX_error_code ktxFileInit(struct ktxStream* stream, FILE* file);
 
 #endif /* _KTXFILESTREAM_H_ */

--- a/lib/ktxfilestream.h
+++ b/lib/ktxfilestream.h
@@ -1,0 +1,48 @@
+/* -*- tab-width: 4; -*- */
+/* vi: set sw=2 ts=4: */
+
+/*
+Copyright (c) 2010 The Khronos Group Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and/or associated documentation files (the
+"Materials"), to deal in the Materials without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Materials, and to
+permit persons to whom the Materials are furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be included
+unaltered in all copies or substantial portions of the Materials.
+Any additions, deletions, or changes to the original source files
+must be clearly indicated in accompanying documentation.
+
+If only executable code is distributed, then the accompanying
+documentation must state that "this software is based in part on the
+work of the Khronos Group".
+
+THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+*/
+
+/*
+ * Author: Maksim Kolesin from original code
+ * by Mark Callow and Georg Kolling
+ */
+
+#ifndef _KTXFILESTREAM_H_
+#define _KTXFILESTREAM_H_
+
+#include "KHR/khrplatform.h"
+#include "ktx.h"
+#include "ktxint.h"
+#include "ktxstream.h"
+
+int ktxFileInit(struct ktxStream* stream, FILE* file);
+
+#endif /* _KTXFILESTREAM_H_ */

--- a/lib/ktxmemstream.c
+++ b/lib/ktxmemstream.c
@@ -64,22 +64,23 @@ MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
 static
 KTX_error_code ktxMem_expand(struct ktxMem *mem, const GLsizei newsize)
 {
-        GLsizei new_alloc_size = mem->alloc_size;
-        while (new_alloc_size < newsize)
-                new_alloc_size <<= 1;
+	GLsizei new_alloc_size = mem->alloc_size;
+	while (new_alloc_size < newsize)
+		new_alloc_size <<= 1;
 
-        if (new_alloc_size == mem->alloc_size)
-                return KTX_SUCCESS;
+	if (new_alloc_size == mem->alloc_size)
+		return KTX_SUCCESS;
 
-        mem->bytes = (unsigned char*)realloc(mem->bytes, new_alloc_size);
-        if(!mem->bytes)
-        {
-                mem->alloc_size = 0;
-                mem->used_size = 0;
-                return KTX_OUT_OF_MEMORY;
-        }
-        mem->alloc_size = new_alloc_size;
-        return KTX_SUCCESS;
+	mem->bytes = (unsigned char*)realloc(mem->bytes, new_alloc_size);
+	if(!mem->bytes)
+	{
+		mem->alloc_size = 0;
+		mem->used_size = 0;
+		return KTX_OUT_OF_MEMORY;
+	}
+
+	mem->alloc_size = new_alloc_size;
+	return KTX_SUCCESS;
 }
 
 /**
@@ -98,15 +99,15 @@ KTX_error_code ktxMem_expand(struct ktxMem *mem, const GLsizei newsize)
 static
 KTX_error_code ktxMemStream_read(void* dst, const GLsizei count, void* src)
 {
-        struct ktxMem* mem = (struct ktxMem*)src;
+	struct ktxMem* mem = (struct ktxMem*)src;
 
-        if(!dst || !mem || (mem->pos + count > mem->used_size) || (mem->pos + count < mem->pos))
-                return KTX_INVALID_VALUE;
+	if(!dst || !mem || (mem->pos + count > mem->used_size) || (mem->pos + count < mem->pos))
+		return KTX_INVALID_VALUE;
 
-        memcpy(dst, mem->bytes + mem->pos, count);
-        mem->pos += count;
+	memcpy(dst, mem->bytes + mem->pos, count);
+	mem->pos += count;
 
-        return KTX_SUCCESS;
+	return KTX_SUCCESS;
 }
 
 /**
@@ -124,14 +125,14 @@ KTX_error_code ktxMemStream_read(void* dst, const GLsizei count, void* src)
 static
 KTX_error_code ktxMemStream_skip(const GLsizei count, void* src)
 {
-        struct ktxMem* mem = (struct ktxMem*)src;
+	struct ktxMem* mem = (struct ktxMem*)src;
 
-        if(!mem || (mem->pos + count > mem->used_size) || (mem->pos + count < mem->pos))
-                return KTX_INVALID_VALUE;
+	if(!mem || (mem->pos + count > mem->used_size) || (mem->pos + count < mem->pos))
+		return KTX_INVALID_VALUE;
 
-        mem->pos += count;
+	mem->pos += count;
 
-        return KTX_SUCCESS;
+	return KTX_SUCCESS;
 }
 
 /**
@@ -152,23 +153,23 @@ KTX_error_code ktxMemStream_skip(const GLsizei count, void* src)
 static
 KTX_error_code ktxMemStream_write(const void* src, const GLsizei size, const GLsizei count, void* dst)
 {
-        struct ktxMem* mem = (struct ktxMem*)dst;
-        KTX_error_code rc = KTX_SUCCESS;
+	struct ktxMem* mem = (struct ktxMem*)dst;
+	KTX_error_code rc = KTX_SUCCESS;
 
-        if(!dst || !mem)
-                return KTX_INVALID_VALUE;
+	if(!dst || !mem)
+		return KTX_INVALID_VALUE;
 
-        if(mem->alloc_size < mem->used_size + size*count)
-        {
-                rc = ktxMem_expand(mem, mem->used_size + size*count);
-                if(rc != KTX_SUCCESS)
-                        return rc;
-        }
+	if(mem->alloc_size < mem->used_size + size*count)
+	{
+		rc = ktxMem_expand(mem, mem->used_size + size*count);
+		if(rc != KTX_SUCCESS)
+			return rc;
+	}
 
-        memcpy(mem->bytes + mem->used_size, src, size*count);
-        mem->used_size += size*count;
+	memcpy(mem->bytes + mem->used_size, src, size*count);
+	mem->used_size += size*count;
 
-        return KTX_SUCCESS;
+	return KTX_SUCCESS;
 }
 
 /**
@@ -193,32 +194,32 @@ KTX_error_code ktxMemStream_write(const void* src, const GLsizei size, const GLs
  */
 KTX_error_code ktxMemInit(struct ktxStream* stream, struct ktxMem* mem, const void* bytes, GLsizei size)
 {
-        if (!stream || !mem || size < 0)
-                return KTX_INVALID_VALUE;
+	if (!stream || !mem || size < 0)
+		return KTX_INVALID_VALUE;
 
-        if(!bytes)
-        {
-                if (size == 0)
-                        size = KTX_MEM_DEFAULT_ALLOCATED_SIZE;
-                mem->bytes = (unsigned char*)malloc(size);
-                if (!mem->bytes)
-                        return KTX_OUT_OF_MEMORY;
-                mem->alloc_size = size;
-                mem->used_size = 0;
-                mem->pos = 0;
-        }
-        else
-        {
-                mem->bytes = (unsigned char*)bytes;
-                mem->used_size = size;
-                mem->alloc_size = size;
-                mem->pos = 0;
-        }
+	if(!bytes)
+	{
+		if (size == 0)
+			size = KTX_MEM_DEFAULT_ALLOCATED_SIZE;
+		mem->bytes = (unsigned char*)malloc(size);
+		if (!mem->bytes)
+			return KTX_OUT_OF_MEMORY;
+		mem->alloc_size = size;
+		mem->used_size = 0;
+		mem->pos = 0;
+	}
+	else
+	{
+		mem->bytes = (unsigned char*)bytes;
+		mem->used_size = size;
+		mem->alloc_size = size;
+		mem->pos = 0;
+	}
 
-        stream->src = mem;
-        stream->read = ktxMemStream_read;
-        stream->skip = ktxMemStream_skip;
-        stream->write = ktxMemStream_write;
+	stream->src = mem;
+	stream->read = ktxMemStream_read;
+	stream->skip = ktxMemStream_skip;
+	stream->write = ktxMemStream_write;
 
-        return KTX_SUCCESS;
+	return KTX_SUCCESS;
 }

--- a/lib/ktxmemstream.c
+++ b/lib/ktxmemstream.c
@@ -1,0 +1,159 @@
+/* -*- tab-width: 4; -*- */
+/* vi: set sw=2 ts=4: */
+
+/**
+ * @file
+ * @~English
+ *
+ * @brief Implementation of ktxStream for memory.
+ *
+ * @author Maksim Kolesin, Under Development
+ * @author Georg Kolling, Imagination Technology
+ * @author Mark Callow, HI Corporation
+ */
+
+/*
+Copyright (c) 2010 The Khronos Group Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and/or associated documentation files (the
+"Materials"), to deal in the Materials without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Materials, and to
+permit persons to whom the Materials are furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be included
+unaltered in all copies or substantial portions of the Materials.
+Any additions, deletions, or changes to the original source files
+must be clearly indicated in accompanying documentation.
+
+If only executable code is distributed, then the accompanying
+documentation must state that "this software is based in part on the
+work of the Khronos Group".
+
+THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+*/
+
+#include <string.h>
+#include <stdlib.h>
+
+#include "KHR/khrplatform.h"
+#include "ktx.h"
+#include "ktxint.h"
+#include "ktxmemstream.h"
+
+static
+int ktxMem_expand(struct ktxMem *mem, const GLsizei newsize)
+{
+        GLsizei new_alloc_size = mem->alloc_size;
+        while (new_alloc_size < newsize) {
+                new_alloc_size <<= 1;
+        }
+        mem->bytes = (unsigned char*)realloc(mem->bytes, new_alloc_size);
+        if(!mem->bytes)
+        {
+                mem->alloc_size = 0;
+                mem->used_size = 0;
+                return 0;
+        }
+        mem->alloc_size = new_alloc_size;
+}
+
+static
+int ktxMemStream_read(void* dst, const GLsizei count, void* src)
+{
+        struct ktxMem* mem = (struct ktxMem*)src;
+
+        if(!dst || !mem || (mem->pos + count > mem->used_size) || (mem->pos + count < mem->pos))
+        {
+                return 0;
+        }
+
+        memcpy(dst, mem->bytes + mem->pos, count);
+        mem->pos += count;
+
+        return 1;
+}
+
+static
+int ktxMemStream_skip(const GLsizei count, void* src)
+{
+        struct ktxMem* mem = (struct ktxMem*)src;
+
+        if(!mem || (mem->pos + count > mem->used_size) || (mem->pos + count < mem->pos))
+        {
+                return 0;
+        }
+
+        mem->pos += count;
+
+        return 1;
+}
+
+static
+int ktxMemStream_write(const void* src, const GLsizei size, const GLsizei count, void* dst)
+{
+        struct ktxMem* mem = (struct ktxMem*)dst;
+
+        if(!dst || !mem)
+        {
+                return 0;
+        }
+
+        if(mem->alloc_size < mem->used_size + size*count)
+        {
+                if(!ktxMem_expand(mem, mem->used_size + size*count))
+                {
+                        return 0;
+                }
+        }
+
+        memcpy(mem->bytes + mem->used_size, src, size*count);
+        mem->used_size += size*count;
+
+        return size*count;
+}
+
+#define KTX_MEM_DEFAULT_ALLOCATED_SIZE 256
+
+int
+ktxMemInit(struct ktxStream* stream, struct ktxMem* mem, const void* bytes, GLsizei size)
+{
+        if (!stream || !mem || size < 0)
+        {
+                return 0;
+        }
+
+        if(!bytes)
+        {
+                if (size == 0)
+                        size = KTX_MEM_DEFAULT_ALLOCATED_SIZE;
+                mem->bytes = (unsigned char*)malloc(size);
+                if (!mem->bytes)
+                        return 0;
+                mem->alloc_size = size;
+                mem->used_size = 0;
+                mem->pos = 0;
+        }
+        else
+        {
+                mem->bytes = (unsigned char*)bytes;
+                mem->used_size = size;
+                mem->alloc_size = size;
+                mem->pos = 0;
+        }
+
+        stream->src = mem;
+        stream->read = ktxMemStream_read;
+        stream->skip = ktxMemStream_skip;
+        stream->write = ktxMemStream_write;
+
+        return 1;
+}

--- a/lib/ktxmemstream.c
+++ b/lib/ktxmemstream.c
@@ -49,87 +49,152 @@ MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
 #include "ktxint.h"
 #include "ktxmemstream.h"
 
+/**
+ * @internal
+ * @~English
+ * @brief Expand a ktxMem to fit to a newsize.
+ *
+ * @param [in] mem           pointer to ktxMem struct to expand.
+ * @param [in] newsize       minimum new size required.
+ *
+ * @return      KTX_SUCCESS on success, KTX_OUT_OF_MEMORY on error.
+ *
+ * @exception KTX_OUT_OF_MEMORY        System failed to allocate sufficient memory.
+ */
 static
-int ktxMem_expand(struct ktxMem *mem, const GLsizei newsize)
+KTX_error_code ktxMem_expand(struct ktxMem *mem, const GLsizei newsize)
 {
         GLsizei new_alloc_size = mem->alloc_size;
-        while (new_alloc_size < newsize) {
+        while (new_alloc_size < newsize)
                 new_alloc_size <<= 1;
-        }
+
+        if (new_alloc_size == mem->alloc_size)
+                return KTX_SUCCESS;
+
         mem->bytes = (unsigned char*)realloc(mem->bytes, new_alloc_size);
         if(!mem->bytes)
         {
                 mem->alloc_size = 0;
                 mem->used_size = 0;
-                return 0;
+                return KTX_OUT_OF_MEMORY;
         }
         mem->alloc_size = new_alloc_size;
+        return KTX_SUCCESS;
 }
 
+/**
+ * @internal
+ * @~English
+ * @brief Read bytes from a ktxMemStream.
+ *
+ * @param [out] dst          pointer to memory where to copy read bytes.
+ * @param [in] count         number of bytes to read.
+ * @param [in] src           pointer to ktxMem struct, converted to a void*, that specifies an input stream.
+ *
+ * @return      KTX_SUCCESS on success, KTX_INVALID_VALUE on error.
+ *
+ * @exception KTX_INVALID_VALUE        @p dst is @c NULL or @p mem is @c NULL or not sufficient data is available in ktxMem.
+ */
 static
-int ktxMemStream_read(void* dst, const GLsizei count, void* src)
+KTX_error_code ktxMemStream_read(void* dst, const GLsizei count, void* src)
 {
         struct ktxMem* mem = (struct ktxMem*)src;
 
         if(!dst || !mem || (mem->pos + count > mem->used_size) || (mem->pos + count < mem->pos))
-        {
-                return 0;
-        }
+                return KTX_INVALID_VALUE;
 
         memcpy(dst, mem->bytes + mem->pos, count);
         mem->pos += count;
 
-        return 1;
+        return KTX_SUCCESS;
 }
 
+/**
+ * @internal
+ * @~English
+ * @brief Skip bytes in a ktxFileStream.
+ *
+ * @param [in] count         number of bytes to skip.
+ * @param [in] src           pointer to a ktxMem struct, converted to a void*, that specifies an input stream.
+ *
+ * @return      KTX_SUCCESS on success, KTX_INVALID_VALUE on error.
+ *
+ * @exception KTX_INVALID_VALUE        @p mem is @c NULL or not sufficient data is available in ktxMem.
+ */
 static
-int ktxMemStream_skip(const GLsizei count, void* src)
+KTX_error_code ktxMemStream_skip(const GLsizei count, void* src)
 {
         struct ktxMem* mem = (struct ktxMem*)src;
 
         if(!mem || (mem->pos + count > mem->used_size) || (mem->pos + count < mem->pos))
-        {
-                return 0;
-        }
+                return KTX_INVALID_VALUE;
 
         mem->pos += count;
 
-        return 1;
+        return KTX_SUCCESS;
 }
 
+/**
+ * @internal
+ * @~English
+ * @brief Write bytes to a ktxFileStream.
+ *
+ * @param [in] src           pointer to the array of elements to be written, converted to a const void*.
+ * @param [in] size          size in bytes of each element to be written.
+ * @param [in] count         number of elements, each one with a @p size of size bytes.
+ * @param [out] dst          pointer to a ktxMem struct, converted to a void*, that specifies an output stream.
+ *
+ * @return      KTX_SUCCESS on success, other KTX_* enum values on error.
+ *
+ * @exception KTX_INVALID_VALUE        @p dst is @c NULL or @p mem is @c NULL.
+ * @exception KTX_OUT_OF_MEMORY        See ktxMem_expand() for causes.
+ */
 static
-int ktxMemStream_write(const void* src, const GLsizei size, const GLsizei count, void* dst)
+KTX_error_code ktxMemStream_write(const void* src, const GLsizei size, const GLsizei count, void* dst)
 {
         struct ktxMem* mem = (struct ktxMem*)dst;
+        KTX_error_code rc = KTX_SUCCESS;
 
         if(!dst || !mem)
-        {
-                return 0;
-        }
+                return KTX_INVALID_VALUE;
 
         if(mem->alloc_size < mem->used_size + size*count)
         {
-                if(!ktxMem_expand(mem, mem->used_size + size*count))
-                {
-                        return 0;
-                }
+                rc = ktxMem_expand(mem, mem->used_size + size*count);
+                if(rc != KTX_SUCCESS)
+                        return rc;
         }
 
         memcpy(mem->bytes + mem->used_size, src, size*count);
         mem->used_size += size*count;
 
-        return count;
+        return KTX_SUCCESS;
 }
 
+/**
+ * @brief Default allocation size for a ktxMemStream.
+ */
 #define KTX_MEM_DEFAULT_ALLOCATED_SIZE 256
 
-int
-ktxMemInit(struct ktxStream* stream, struct ktxMem* mem, const void* bytes, GLsizei size)
+/**
+ * @internal
+ * @~English
+ * @brief Initialize a ktxMemStream.
+ *
+ * @param [in] stream        pointer to a ktxStream struct to initialize.
+ * @param [in] mem           pointer to a ktxMem struct to use in ktxMemStream.
+ * @param [in] bytes         pointer to an array of bytes to use as initial data.
+ * @param [in] size          size of array of initial data for ktxMemStream.
+ *
+ * @return      KTX_SUCCESS on success, other KTX_* enum values on error.
+ *
+ * @exception KTX_INVALID_VALUE        @p stream is @c NULL or @p mem is @c NULL or @p size is less than 0.
+ * @exception KTX_OUT_OF_MEMORY        system failed to allocate sufficient memory.
+ */
+KTX_error_code ktxMemInit(struct ktxStream* stream, struct ktxMem* mem, const void* bytes, GLsizei size)
 {
         if (!stream || !mem || size < 0)
-        {
-                return 0;
-        }
+                return KTX_INVALID_VALUE;
 
         if(!bytes)
         {
@@ -137,7 +202,7 @@ ktxMemInit(struct ktxStream* stream, struct ktxMem* mem, const void* bytes, GLsi
                         size = KTX_MEM_DEFAULT_ALLOCATED_SIZE;
                 mem->bytes = (unsigned char*)malloc(size);
                 if (!mem->bytes)
-                        return 0;
+                        return KTX_OUT_OF_MEMORY;
                 mem->alloc_size = size;
                 mem->used_size = 0;
                 mem->pos = 0;
@@ -155,5 +220,5 @@ ktxMemInit(struct ktxStream* stream, struct ktxMem* mem, const void* bytes, GLsi
         stream->skip = ktxMemStream_skip;
         stream->write = ktxMemStream_write;
 
-        return 1;
+        return KTX_SUCCESS;
 }

--- a/lib/ktxmemstream.c
+++ b/lib/ktxmemstream.c
@@ -118,7 +118,7 @@ int ktxMemStream_write(const void* src, const GLsizei size, const GLsizei count,
         memcpy(mem->bytes + mem->used_size, src, size*count);
         mem->used_size += size*count;
 
-        return size*count;
+        return count;
 }
 
 #define KTX_MEM_DEFAULT_ALLOCATED_SIZE 256

--- a/lib/ktxmemstream.h
+++ b/lib/ktxmemstream.h
@@ -50,10 +50,10 @@ MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
  */
 struct ktxMem
 {
-        unsigned char* bytes;
-        GLsizei alloc_size;
-        GLsizei used_size;
-        GLsizei pos;
+	unsigned char* bytes;
+	GLsizei alloc_size;
+	GLsizei used_size;
+	GLsizei pos;
 };
 
 /*

--- a/lib/ktxmemstream.h
+++ b/lib/ktxmemstream.h
@@ -43,6 +43,11 @@ MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
 #include "ktxint.h"
 #include "ktxstream.h"
 
+/**
+ * @internal
+ * @brief Structure to store information
+ *    about data allocated for ktxMemStream
+ */
 struct ktxMem
 {
         unsigned char* bytes;
@@ -51,6 +56,9 @@ struct ktxMem
         GLsizei pos;
 };
 
-int ktxMemInit(struct ktxStream* stream, struct ktxMem* mem, const void* bytes, GLsizei size);
+/*
+ * ktxMemInit: Initialize a ktxStream to a ktxMemStream with ktxMem struct and/or array of bytes
+ */
+KTX_error_code ktxMemInit(struct ktxStream* stream, struct ktxMem* mem, const void* bytes, GLsizei size);
 
 #endif /* _KTXMEMSTREAM_H_ */

--- a/lib/ktxmemstream.h
+++ b/lib/ktxmemstream.h
@@ -1,0 +1,56 @@
+/* -*- tab-width: 4; -*- */
+/* vi: set sw=2 ts=4: */
+
+/*
+Copyright (c) 2010 The Khronos Group Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and/or associated documentation files (the
+"Materials"), to deal in the Materials without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Materials, and to
+permit persons to whom the Materials are furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be included
+unaltered in all copies or substantial portions of the Materials.
+Any additions, deletions, or changes to the original source files
+must be clearly indicated in accompanying documentation.
+
+If only executable code is distributed, then the accompanying
+documentation must state that "this software is based in part on the
+work of the Khronos Group".
+
+THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+*/
+
+/*
+ * Author: Maksim Kolesin from original code
+ * by Mark Callow and Georg Kolling
+ */
+
+#ifndef _KTXMEMSTREAM_H_
+#define _KTXMEMSTREAM_H_
+
+#include "KHR/khrplatform.h"
+#include "ktx.h"
+#include "ktxint.h"
+#include "ktxstream.h"
+
+struct ktxMem
+{
+        unsigned char* bytes;
+        GLsizei alloc_size;
+        GLsizei used_size;
+        GLsizei pos;
+};
+
+int ktxMemInit(struct ktxStream* stream, struct ktxMem* mem, const void* bytes, GLsizei size);
+
+#endif /* _KTXMEMSTREAM_H_ */

--- a/lib/ktxstream.h
+++ b/lib/ktxstream.h
@@ -75,10 +75,10 @@ typedef KTX_error_code(*ktxStream_write)(const void *src, const GLsizei size, co
  */
 struct ktxStream
 {
-        void* src;                              /**< pointer to the stream source */
-        ktxStream_read read;    /**< pointer to function for reading bytes */
-        ktxStream_skip skip;    /**< pointer to function for skipping bytes */
-        ktxStream_write write;  /**< pointer to function for writing bytes */
+	void* src;                              /**< pointer to the stream source */
+	ktxStream_read read;    /**< pointer to function for reading bytes */
+	ktxStream_skip skip;    /**< pointer to function for skipping bytes */
+	ktxStream_write write;  /**< pointer to function for writing bytes */
 };
 
 #endif /* _KTXSTREAM_H_ */

--- a/lib/ktxstream.h
+++ b/lib/ktxstream.h
@@ -38,24 +38,35 @@ MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
 #ifndef _KTXSTREAM_H_
 #define _KTXSTREAM_H_
 
+#include "ktx.h"
+
+/* @private is not preventing the typedefs, structs and defines from
+ * appearing in the Doxygen output even though EXTRACT_PRIVATE is NO
+ * in the config file. To prevent these items appearing I have changed
+ * the special comments to ordinary comments, and have set
+ * HIDE_UNDOC_MEMBERS = YES in the Doxygen config file.
+ *
+ * Items declared "static" are omitted, as expected, due to EXTRACT_STATIC
+ * being NO, so there is no need to convert those to ordinary comments.
+ */
 /*
  * @private
  * @~English
  * @brief type for a pointer to a stream reading function
  */
-typedef int(*ktxStream_read)(void* dst, const GLsizei count, void* src);
+typedef KTX_error_code(*ktxStream_read)(void* dst, const GLsizei count, void* src);
 /*
  * @private
  * @~English
  * @brief type for a pointer to a stream skipping function
  */
-typedef int(*ktxStream_skip)(const GLsizei count, void* src);
+typedef KTX_error_code(*ktxStream_skip)(const GLsizei count, void* src);
 /*
  * @private
  * @~English
  * @brief type for a pointer to a stream reading function
  */
-typedef int(*ktxStream_write)(const void *src, const GLsizei size, const GLsizei count, void* dst);
+typedef KTX_error_code(*ktxStream_write)(const void *src, const GLsizei size, const GLsizei count, void* dst);
 
 /*
  * @private

--- a/lib/ktxstream.h
+++ b/lib/ktxstream.h
@@ -1,0 +1,73 @@
+/* -*- tab-width: 4; -*- */
+/* vi: set sw=2 ts=4: */
+
+/*
+Copyright (c) 2010 The Khronos Group Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and/or associated documentation files (the
+"Materials"), to deal in the Materials without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Materials, and to
+permit persons to whom the Materials are furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be included
+unaltered in all copies or substantial portions of the Materials.
+Any additions, deletions, or changes to the original source files
+must be clearly indicated in accompanying documentation.
+
+If only executable code is distributed, then the accompanying
+documentation must state that "this software is based in part on the
+work of the Khronos Group".
+
+THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+*/
+
+/*
+ * Author: Maksim Kolesin from original code
+ * by Mark Callow and Georg Kolling
+ */
+
+#ifndef _KTXSTREAM_H_
+#define _KTXSTREAM_H_
+
+/*
+ * @private
+ * @~English
+ * @brief type for a pointer to a stream reading function
+ */
+typedef int(*ktxStream_read)(void* dst, const GLsizei count, void* src);
+/*
+ * @private
+ * @~English
+ * @brief type for a pointer to a stream skipping function
+ */
+typedef int(*ktxStream_skip)(const GLsizei count, void* src);
+/*
+ * @private
+ * @~English
+ * @brief type for a pointer to a stream reading function
+ */
+typedef int(*ktxStream_write)(const void *src, const GLsizei size, const GLsizei count, void* dst);
+
+/*
+ * @private
+ * @~English
+ * @brief KTX stream interface
+ */
+struct ktxStream
+{
+        void* src;                              /**< pointer to the stream source */
+        ktxStream_read read;    /**< pointer to function for reading bytes */
+        ktxStream_skip skip;    /**< pointer to function for skipping bytes */
+        ktxStream_write write;  /**< pointer to function for writing bytes */
+};
+
+#endif /* _KTXSTREAM_H_ */

--- a/lib/loader.c
+++ b/lib/loader.c
@@ -134,7 +134,7 @@ static GLboolean supportsSRGB = GL_TRUE;
  * @private
  * @~English
  * @brief Discover the capabilities of the current GL context.
- * 
+ *
  * Queries the context and sets several the following internal variables indicating
  * the capabilities of the context:
  *
@@ -143,7 +143,7 @@ static GLboolean supportsSRGB = GL_TRUE;
  * @li supportsSRGB
  * @li b16Formats
  *
- */           
+ */
 static void discoverContextCapabilities(void)
 {
 	GLint majorVersion = 1;
@@ -210,7 +210,7 @@ static void discoverContextCapabilities(void)
  * @internal
  * @~English
  * @brief Convert deprecated legacy-format texture to modern format.
- * 
+ *
  * The function sets the GL_TEXTURE_SWIZZLEs necessary to get the same
  * behavior as the legacy format.
  *
@@ -223,7 +223,7 @@ static void discoverContextCapabilities(void)
  *                                   written here.
  * @return void unrecognized formats will be passed on to OpenGL. Any loading error
  *              that arises will be handled in the usual way.
- */           
+ */
 static void convertFormat(GLenum target, GLenum* pFormat, GLenum* pInternalFormat) {
 	switch (*pFormat) {
 	  case GL_ALPHA:
@@ -330,10 +330,10 @@ static void convertFormat(GLenum target, GLenum* pFormat, GLenum* pInternalForma
  * textures in software when the format is not supported by the GL context,
  * provided the library has been compiled with SUPPORT_SOFTWARE_ETC_UNPACK
  * defined as 1.
- * 
+ *
  * It will also convert textures with legacy formats to their modern equivalents
  * when the format is not supported by the GL context, provided that the library
- * has been compiled with SUPPORT_LEGACY_FORMAT_CONVERSION defined as 1. 
+ * has been compiled with SUPPORT_LEGACY_FORMAT_CONVERSION defined as 1.
  *
  * @param [in] stream		pointer to the ktxStream from which to load.
  * @param [in,out] pTexture	name of the GL texture to load. If NULL or if
@@ -358,7 +358,7 @@ static void convertFormat(GLenum target, GLenum* pFormat, GLenum* pInternalForma
  *                          KTX_GL_ERROR. glerror can be NULL.
  * @param [in,out] pKvdLen	If not NULL, @p *pKvdLen is set to the number of bytes
  *                          of key-value data pointed at by @p *ppKvd. Must not be
- *                          NULL, if @p ppKvd is not NULL.                     
+ *                          NULL, if @p ppKvd is not NULL.
  * @param [in,out] ppKvd	If not NULL, @p *ppKvd is set to the point to a block of
  *                          memory containing key-value data read from the file.
  *                          The application is responsible for freeing the memory.
@@ -406,7 +406,7 @@ ktxLoadTextureS(struct ktxStream* stream, GLuint* pTexture, GLenum* pTarget,
 
 	if (ppKvd) {
 		*ppKvd = NULL;
-        }
+	}
 
 	if (!stream || !stream->read || !stream->skip) {
 		return KTX_INVALID_VALUE;
@@ -416,7 +416,7 @@ ktxLoadTextureS(struct ktxStream* stream, GLuint* pTexture, GLenum* pTarget,
 		return KTX_INVALID_VALUE;
 	}
 
-        errorCode = stream->read(&header, KTX_HEADER_SIZE, stream->src);
+	errorCode = stream->read(&header, KTX_HEADER_SIZE, stream->src);
 	if (errorCode != KTX_SUCCESS)
 		return errorCode;
 
@@ -432,7 +432,7 @@ ktxLoadTextureS(struct ktxStream* stream, GLuint* pTexture, GLenum* pTarget,
 			*ppKvd = (unsigned char*)malloc(*pKvdLen);
 			if (*ppKvd == NULL)
 				return KTX_OUT_OF_MEMORY;
-                        errorCode = stream->read(*ppKvd, *pKvdLen, stream->src);
+			errorCode = stream->read(*ppKvd, *pKvdLen, stream->src);
 			if (errorCode != KTX_SUCCESS)
 			{
 				free(*ppKvd);
@@ -443,7 +443,7 @@ ktxLoadTextureS(struct ktxStream* stream, GLuint* pTexture, GLenum* pTarget,
 		}
 	} else {
 		/* skip key/value metadata */
-                errorCode = stream->skip((long)header.bytesOfKeyValueData, stream->src);
+		errorCode = stream->skip((long)header.bytesOfKeyValueData, stream->src);
 		if (errorCode != KTX_SUCCESS) {
 			return errorCode;
 		}
@@ -492,7 +492,7 @@ ktxLoadTextureS(struct ktxStream* stream, GLuint* pTexture, GLenum* pTarget,
 		// supported, must change internal format.
 		if (sizedFormats == _NO_SIZED_FORMATS
 			|| (!(sizedFormats & _LEGACY_FORMATS) &&
-				(header.glBaseInternalFormat == GL_ALPHA	
+				(header.glBaseInternalFormat == GL_ALPHA
 				|| header.glBaseInternalFormat == GL_LUMINANCE
 				|| header.glBaseInternalFormat == GL_LUMINANCE_ALPHA
 				|| header.glBaseInternalFormat == GL_INTENSITY))) {
@@ -507,7 +507,7 @@ ktxLoadTextureS(struct ktxStream* stream, GLuint* pTexture, GLenum* pTarget,
 		GLsizei pixelHeight = MAX(1, header.pixelHeight >> level);
 		GLsizei pixelDepth  = MAX(1, header.pixelDepth  >> level);
 
-                errorCode = stream->read(&faceLodSize, sizeof(khronos_uint32_t), stream->src);
+		errorCode = stream->read(&faceLodSize, sizeof(khronos_uint32_t), stream->src);
 		if (errorCode != KTX_SUCCESS) {
 			goto cleanup;
 		}
@@ -532,7 +532,7 @@ ktxLoadTextureS(struct ktxStream* stream, GLuint* pTexture, GLenum* pTarget,
 
 		for (face = 0; face < header.numberOfFaces; ++face)
 		{
-                        errorCode = stream->read(data, faceLodSizeRounded, stream->src);
+			errorCode = stream->read(data, faceLodSizeRounded, stream->src);
 			if (errorCode != KTX_SUCCESS) {
 				goto cleanup;
 			}
@@ -563,12 +563,12 @@ ktxLoadTextureS(struct ktxStream* stream, GLuint* pTexture, GLenum* pTarget,
 				    // It is simpler to just attempt to load the format, rather than divine which
 					// formats are supported by the implementation. In the event of an error,
 					// software unpacking can be attempted.
-					glCompressedTexImage2D(texinfo.glTarget + face, level, 
+					glCompressedTexImage2D(texinfo.glTarget + face, level,
 						glInternalFormat, pixelWidth, pixelHeight, 0,
 						faceLodSize, data);
 				} else {
-					glTexImage2D(texinfo.glTarget + face, level, 
-						glInternalFormat, pixelWidth, pixelHeight, 0, 
+					glTexImage2D(texinfo.glTarget + face, level,
+						glInternalFormat, pixelWidth, pixelHeight, 0,
 						glFormat, header.glType, data);
 				}
 			} else if (texinfo.textureDimensions == 3) {
@@ -576,12 +576,12 @@ ktxLoadTextureS(struct ktxStream* stream, GLuint* pTexture, GLenum* pTarget,
 					pixelDepth = header.numberOfArrayElements;
 				}
 				if (texinfo.compressed) {
-					glCompressedTexImage3D(texinfo.glTarget + face, level, 
+					glCompressedTexImage3D(texinfo.glTarget + face, level,
 						glInternalFormat, pixelWidth, pixelHeight, pixelDepth, 0,
 						faceLodSize, data);
 				} else {
-					glTexImage3D(texinfo.glTarget + face, level, 
-						glInternalFormat, pixelWidth, pixelHeight, pixelDepth, 0, 
+					glTexImage3D(texinfo.glTarget + face, level,
+						glInternalFormat, pixelWidth, pixelHeight, pixelDepth, 0,
 						glFormat, header.glType, data);
 				}
 			}
@@ -593,7 +593,7 @@ ktxLoadTextureS(struct ktxStream* stream, GLuint* pTexture, GLenum* pTarget,
 				&& texinfo.compressed
 				&& texinfo.textureDimensions == 2
 				&& (glInternalFormat == GL_ETC1_RGB8_OES || (glInternalFormat >= GL_COMPRESSED_R11_EAC && glInternalFormat <= GL_COMPRESSED_SRGB8_ALPHA8_ETC2_EAC)))
-			    {
+			{
 				GLubyte* unpacked;
 				GLenum format, internalFormat, type;
 
@@ -609,8 +609,8 @@ ktxLoadTextureS(struct ktxStream* stream, GLuint* pTexture, GLenum* pTarget,
 					else if (internalFormat == GL_RGBA8)
 						internalFormat = GL_RGBA;
 				}
-				glTexImage2D(texinfo.glTarget + face, level, 
-							 internalFormat, pixelWidth, pixelHeight, 0, 
+				glTexImage2D(texinfo.glTarget + face, level,
+							 internalFormat, pixelWidth, pixelHeight, 0,
 							 format, type, unpacked);
 
 				free(unpacked);
@@ -676,10 +676,10 @@ cleanup:
  * textures in software when the format is not supported by the GL context,
  * provided the library has been compiled with SUPPORT_SOFTWARE_ETC_UNPACK
  * defined as 1.
- * 
+ *
  * It will also convert texture with legacy formats to their modern equivalents
  * when the format is not supported by the GL context, provided that the library
- * has been compiled with SUPPORT_LEGACY_FORMAT_CONVERSION defined as 1. 
+ * has been compiled with SUPPORT_LEGACY_FORMAT_CONVERSION defined as 1.
  *
  * @param [in] file			pointer to the stdio FILE stream from which to
  * 							load.
@@ -705,7 +705,7 @@ cleanup:
  *                          KTX_GL_ERROR. glerror can be NULL.
  * @param [in,out] pKvdLen	If not NULL, @p *pKvdLen is set to the number of bytes
  *                          of key-value data pointed at by @p *ppKvd. Must not be
- *                          NULL, if @p ppKvd is not NULL.                     
+ *                          NULL, if @p ppKvd is not NULL.
  * @param [in,out] ppKvd	If not NULL, @p *ppKvd is set to the point to a block of
  *                          memory containing key-value data read from the file.
  *                          The application is responsible for freeing the memory.
@@ -733,9 +733,9 @@ ktxLoadTextureF(FILE* file, GLuint* pTexture, GLenum* pTarget,
 				unsigned int* pKvdLen, unsigned char** ppKvd)
 {
 	struct ktxStream stream;
-        KTX_error_code errorCode = KTX_SUCCESS;
+	KTX_error_code errorCode = KTX_SUCCESS;
 
-        errorCode = ktxFileInit(&stream, file);
+	errorCode = ktxFileInit(&stream, file);
 	if (errorCode != KTX_SUCCESS)
 		return errorCode;
 
@@ -773,7 +773,7 @@ ktxLoadTextureF(FILE* file, GLuint* pTexture, GLenum* pTarget,
  * @exception KTX_INVALID_VALUE		See ktxLoadTextureF() for causes.
  * @exception KTX_INVALID_OPERATION	See ktxLoadTextureF() for causes.
  * @exception KTX_UNEXPECTED_END_OF_FILE See ktxLoadTextureF() for causes.
- * 								
+ *
  * @exception KTX_GL_ERROR			See ktxLoadTextureF() for causes.
  */
 KTX_error_code
@@ -790,7 +790,7 @@ ktxLoadTextureN(const char* const filename, GLuint* pTexture, GLenum* pTarget,
 								    pIsMipmapped, pGlerror, pKvdLen, ppKvd);
 		fclose(file);
 	} else
-	    errorCode = KTX_FILE_OPEN_FAILED;
+		errorCode = KTX_FILE_OPEN_FAILED;
 
 	return errorCode;
 }
@@ -818,7 +818,7 @@ ktxLoadTextureN(const char* const filename, GLuint* pTexture, GLenum* pTarget,
  *                          KTX_GL_ERROR. glerror can be NULL.
  * @param [in,out] pKvdLen	If not NULL, @p *pKvdLen is set to the number of bytes
  *                          of key-value data pointed at by @p *ppKvd. Must not be
- *                          NULL, if @p ppKvd is not NULL.                     
+ *                          NULL, if @p ppKvd is not NULL.
  * @param [in,out] ppKvd	If not NULL, @p *ppKvd is set to the point to a block of
  *                          memory containing key-value data read from the file.
  *                          The application is responsible for freeing the memory.*
@@ -829,7 +829,7 @@ ktxLoadTextureN(const char* const filename, GLuint* pTexture, GLenum* pTarget,
  * @exception KTX_INVALID_VALUE		See ktxLoadTextureF() for causes.
  * @exception KTX_INVALID_OPERATION	See ktxLoadTextureF() for causes.
  * @exception KTX_UNEXPECTED_END_OF_FILE See ktxLoadTextureF() for causes.
- * 								
+ *
  * @exception KTX_GL_ERROR			See ktxLoadTextureF() for causes.
  */
 KTX_error_code
@@ -840,9 +840,9 @@ ktxLoadTextureM(const void* bytes, GLsizei size, GLuint* pTexture, GLenum* pTarg
 {
 	struct ktxMem mem;
 	struct ktxStream stream;
-        KTX_error_code errorCode = KTX_SUCCESS;
+	KTX_error_code errorCode = KTX_SUCCESS;
 
-        errorCode = ktxMemInit(&stream, &mem, bytes, size);
+	errorCode = ktxMemInit(&stream, &mem, bytes, size);
 	if (errorCode != KTX_SUCCESS)
 		return errorCode;
 

--- a/lib/writer.c
+++ b/lib/writer.c
@@ -139,7 +139,7 @@ ktxWriteKTXS(struct ktxStream *stream, const KTX_texture_info* textureInfo,
 		header.glTypeSize != 2 &&
 		header.glTypeSize != 4)
 	{
-		/* Only 8, 16, and 32-bit types are supported for byte-swapping. 
+		/* Only 8, 16, and 32-bit types are supported for byte-swapping.
 		 * See UNPACK_SWAP_BYTES & table 8.4 in the OpenGL 4.4 spec.
 		 */
 		return KTX_INVALID_VALUE;
@@ -181,8 +181,8 @@ ktxWriteKTXS(struct ktxStream *stream, const KTX_texture_info* textureInfo,
 
 
 	/* Check texture dimensions. KTX files can store 8 types of textures:
-     * 1D, 2D, 3D, cube, and array variants of these. There is currently
-     * no GL extension that would accept 3D array or cube array textures
+	 * 1D, 2D, 3D, cube, and array variants of these. There is currently
+	 * no GL extension that would accept 3D array or cube array textures
 	 * but we'll let such files be created.
 	 */
 	if ((header.pixelWidth == 0) ||
@@ -190,7 +190,7 @@ ktxWriteKTXS(struct ktxStream *stream, const KTX_texture_info* textureInfo,
 	{
 		/* texture must have width */
 		/* texture must have height if it has depth */
-		return KTX_INVALID_VALUE; 
+		return KTX_INVALID_VALUE;
 	}
 	if (header.pixelHeight > 0 && header.pixelDepth > 0)
 		dimension = 3;
@@ -225,7 +225,7 @@ ktxWriteKTXS(struct ktxStream *stream, const KTX_texture_info* textureInfo,
 			cubemap = 1;
 	}
 	else
-	    numArrayElements = header.numberOfArrayElements;
+		numArrayElements = header.numberOfArrayElements;
 
 	/* Check number of mipmap levels */
 	if (header.numberOfMipmapLevels == 0)
@@ -251,15 +251,15 @@ ktxWriteKTXS(struct ktxStream *stream, const KTX_texture_info* textureInfo,
 
 	//write header
 	errorCode = stream->write(&header, sizeof(KTX_header), 1, stream->src);
-        if (errorCode != KTX_SUCCESS)
-                return errorCode;
+	if (errorCode != KTX_SUCCESS)
+		return errorCode;
 
 	//write keyValueData
 	if (bytesOfKeyValueData != 0) {
 		if (keyValueData == NULL)
 			return KTX_INVALID_OPERATION;
 
-                errorCode = stream->write(keyValueData, 1, bytesOfKeyValueData, stream->src);
+		errorCode = stream->write(keyValueData, 1, bytesOfKeyValueData, stream->src);
 		if (errorCode != KTX_SUCCESS)
 			return errorCode;
 	}
@@ -303,7 +303,7 @@ ktxWriteKTXS(struct ktxStream *stream, const KTX_texture_info* textureInfo,
 		}
 		faceLodRounding = 3 - ((faceLodSize + 3) % 4);
 
-                errorCode = stream->write(&faceLodSize, sizeof(faceLodSize), 1, stream->src);
+		errorCode = stream->write(&faceLodSize, sizeof(faceLodSize), 1, stream->src);
 		if (errorCode != KTX_SUCCESS)
 			goto cleanup;
 
@@ -317,7 +317,7 @@ ktxWriteKTXS(struct ktxStream *stream, const KTX_texture_info* textureInfo,
 			}
 			if (rowRounding == 0) {
 				/* Can write whole face at once */
-                                errorCode = stream->write(images[i].data, faceLodSize, 1, stream->src);
+				errorCode = stream->write(images[i].data, faceLodSize, 1, stream->src);
 				if (errorCode != KTX_SUCCESS)
 					goto cleanup;
 			} else {
@@ -327,17 +327,17 @@ ktxWriteKTXS(struct ktxStream *stream, const KTX_texture_info* textureInfo,
 								* pixelDepth
 								* numArrayElements;
 				for (row = 0; row < numRows; row++) {
-                                        errorCode = stream->write(&images[i].data[row*packedRowBytes], packedRowBytes, 1, stream->src);
+					errorCode = stream->write(&images[i].data[row*packedRowBytes], packedRowBytes, 1, stream->src);
 					if (errorCode != KTX_SUCCESS)
 						goto cleanup;
 
-                                        errorCode = stream->write(pad, sizeof(GLbyte), rowRounding, stream->src);
+					errorCode = stream->write(pad, sizeof(GLbyte), rowRounding, stream->src);
 					if (errorCode != KTX_SUCCESS)
 						goto cleanup;
 				}
 			}
 			if (faceLodRounding) {
-                                errorCode = stream->write(pad, sizeof(GLbyte), faceLodRounding, stream->src);
+				errorCode = stream->write(pad, sizeof(GLbyte), faceLodRounding, stream->src);
 				if (errorCode != KTX_SUCCESS)
 					goto cleanup;
 			}
@@ -392,17 +392,17 @@ cleanup:
  */
 KTX_error_code
 ktxWriteKTXF(FILE *file, const KTX_texture_info* textureInfo,
-                         GLsizei bytesOfKeyValueData, const void* keyValueData,
-                         GLuint numImages, KTX_image_info images[])
+						 GLsizei bytesOfKeyValueData, const void* keyValueData,
+						 GLuint numImages, KTX_image_info images[])
 {
-        struct ktxStream stream;
-        KTX_error_code errorCode = KTX_SUCCESS;
+		struct ktxStream stream;
+		KTX_error_code errorCode = KTX_SUCCESS;
 
-        errorCode = ktxFileInit(&stream, file);
-        if (errorCode != KTX_SUCCESS)
-                return errorCode;
+		errorCode = ktxFileInit(&stream, file);
+		if (errorCode != KTX_SUCCESS)
+				return errorCode;
 
-        return ktxWriteKTXS(&stream, textureInfo, bytesOfKeyValueData, keyValueData, numImages, images);
+		return ktxWriteKTXS(&stream, textureInfo, bytesOfKeyValueData, keyValueData, numImages, images);
 }
 
 /**
@@ -432,16 +432,16 @@ KTX_error_code
 ktxWriteKTXN(const char* dstname, const KTX_texture_info* textureInfo,
 			 GLsizei bytesOfKeyValueData, const void* keyValueData,
 			 GLuint numImages, KTX_image_info images[])
-{	
+{
 	KTX_error_code errorCode;
 	FILE* dst = fopen(dstname, "wb");
 
 	if (dst) {
 		errorCode = ktxWriteKTXF(dst, textureInfo, bytesOfKeyValueData, keyValueData,
-			                     numImages, images);
+								 numImages, images);
 		fclose(dst);
 	} else
-	    errorCode = KTX_FILE_OPEN_FAILED;
+		errorCode = KTX_FILE_OPEN_FAILED;
 
 	return errorCode;
 }
@@ -451,7 +451,7 @@ ktxWriteKTXN(const char* dstname, const KTX_texture_info* textureInfo,
  * @brief Write image(s) in KTX format to memory.
  *
  * @param [out] bytes        pointer to the output with KTX data. Application
-                            is responsible for freeing that memory.
+							is responsible for freeing that memory.
  * @param [out] size         pointer to store size of the memory written.
  * @param [in] textureInfo  pointer to a KTX_image_info structure providing
  *                          information about the images to be included in
@@ -468,32 +468,32 @@ ktxWriteKTXN(const char* dstname, const KTX_texture_info* textureInfo,
  */
 KTX_error_code
 ktxWriteKTXM(unsigned char** bytes, GLsizei* size, const KTX_texture_info* textureInfo,
-                         GLsizei bytesOfKeyValueData, const void* keyValueData,
-                         GLuint numImages, KTX_image_info images[])
+			GLsizei bytesOfKeyValueData, const void* keyValueData,
+			GLuint numImages, KTX_image_info images[])
 {
-        struct ktxMem mem;
-        struct ktxStream stream;
-        KTX_error_code rc;
+	struct ktxMem mem;
+	struct ktxStream stream;
+	KTX_error_code rc;
 
-        *bytes = NULL;
+	*bytes = NULL;
 
-        rc = ktxMemInit(&stream, &mem, NULL, 0);
-        if (rc != KTX_SUCCESS)
-                return rc;
+	rc = ktxMemInit(&stream, &mem, NULL, 0);
+	if (rc != KTX_SUCCESS)
+		return rc;
 
-        rc = ktxWriteKTXS(&stream, textureInfo, bytesOfKeyValueData, keyValueData, numImages, images);
-        if(rc != KTX_SUCCESS)
-        {
-                if(mem.bytes)
-                {
-                        free(mem.bytes);
-                }
-                return rc;
-        }
+	rc = ktxWriteKTXS(&stream, textureInfo, bytesOfKeyValueData, keyValueData, numImages, images);
+	if(rc != KTX_SUCCESS)
+	{
+		if(mem.bytes)
+		{
+			free(mem.bytes);
+		}
+		return rc;
+	}
 
-        *bytes = mem.bytes;
-        *size = mem.used_size;
-        return KTX_SUCCESS;
+	*bytes = mem.bytes;
+	*size = mem.used_size;
+	return KTX_SUCCESS;
 }
 
 /*

--- a/lib/writer.c
+++ b/lib/writer.c
@@ -318,7 +318,7 @@ ktxWriteKTXS(struct ktxStream *stream, const KTX_texture_info* textureInfo,
 			if (rowRounding == 0) {
 				/* Can write whole face at once */
                                 errorCode = stream->write(images[i].data, faceLodSize, 1, stream->src);
- 				if (errorCode != KTX_SUCCESS)
+				if (errorCode != KTX_SUCCESS)
 					goto cleanup;
 			} else {
 				/* Write the rows individually, padding each one */

--- a/lib/writer.c
+++ b/lib/writer.c
@@ -467,7 +467,7 @@ ktxWriteKTXN(const char* dstname, const KTX_texture_info* textureInfo,
  *
  */
 KTX_error_code
-ktxWriteKTXM(const void **bytes, GLsizei *size, const KTX_texture_info* textureInfo,
+ktxWriteKTXM(unsigned char** bytes, GLsizei* size, const KTX_texture_info* textureInfo,
                          GLsizei bytesOfKeyValueData, const void* keyValueData,
                          GLuint numImages, KTX_image_info images[])
 {


### PR DESCRIPTION
This patch moves code of ktxStream and its implementations into separate files. It also adds function ktxWriteKTXM which writes KTX data into memory region.