### PR TITLE
fixed warnings

### DIFF
--- a/lib/etcdec.cxx
+++ b/lib/etcdec.cxx
@@ -289,8 +289,8 @@ void read_big_endian_2byte_word(unsigned short *blockadr, FILE *f)
 	uint8 bytes[2];
 	unsigned short block;
 
-	fread(&bytes[0], 1, 1, f);
-	fread(&bytes[1], 1, 1, f);
+	(void) fread(&bytes[0], 1, 1, f);
+	(void) fread(&bytes[1], 1, 1, f);
 
 	block = 0;
 	block |= bytes[0];
@@ -307,10 +307,10 @@ void read_big_endian_4byte_word(unsigned int *blockadr, FILE *f)
 	uint8 bytes[4];
 	unsigned int block;
 
-	fread(&bytes[0], 1, 1, f);
-	fread(&bytes[1], 1, 1, f);
-	fread(&bytes[2], 1, 1, f);
-	fread(&bytes[3], 1, 1, f);
+	(void) fread(&bytes[0], 1, 1, f);
+	(void) fread(&bytes[1], 1, 1, f);
+	(void) fread(&bytes[2], 1, 1, f);
+	(void) fread(&bytes[3], 1, 1, f);
 
 	block = 0;
 	block |= bytes[0];


### PR DESCRIPTION
external/libktx/lib/etcdec.cxx:292:27: warning: ignoring return value of ‘size_t fread(void*, size_t, size_t, FILE*)’, declared with attribute warn_unused_result [-Wunused-result]
external/libktx/lib/etcdec.cxx:293:27: warning: ignoring return value of ‘size_t fread(void*, size_t, size_t, FILE*)’, declared with attribute warn_unused_result [-Wunused-result]
external/libktx/lib/etcdec.cxx:310:27: warning: ignoring return value of ‘size_t fread(void*, size_t, size_t, FILE*)’, declared with attribute warn_unused_result [-Wunused-result]
external/libktx/lib/etcdec.cxx:311:27: warning: ignoring return value of ‘size_t fread(void*, size_t, size_t, FILE*)’, declared with attribute warn_unused_result [-Wunused-result]
external/libktx/lib/etcdec.cxx:312:27: warning: ignoring return value of ‘size_t fread(void*, size_t, size_t, FILE*)’, declared with attribute warn_unused_result [-Wunused-result]
external/libktx/lib/etcdec.cxx:313:27: warning: ignoring return value of ‘size_t fread(void*, size_t, size_t, FILE*)’, declared with attribute warn_unused_result [-Wunused-result]

Change-Id: Ifd0833680c463048b4648758d9bf7aa1f6b2c9ef

(cherry picked from commit 8bf398f675924e897da5f1edf92545ab1e62bf4b)

(cherry picked from commit 8bf398f675924e897da5f1edf92545ab1e62bf4b)