### PR TITLE
WIP: set GL_TEXTURE_MAX_LEVEL to complete texture

### DIFF
--- a/lib/loader.c
+++ b/lib/loader.c
@@ -470,6 +470,10 @@ ktxLoadTextureS(struct ktxStream* stream, GLuint* pTexture, GLenum* pTarget,
 	if (texinfo.generateMipmaps && (glGenerateMipmap == NULL)) {
 		glTexParameteri(texinfo.glTarget, GL_GENERATE_MIPMAP, GL_TRUE);
 	}
+#ifdef GL_TEXTURE_MAX_LEVEL
+	if (!texinfo.generateMipmaps)
+		glTexParameteri(texinfo.glTarget, GL_TEXTURE_MAX_LEVEL, header.numberOfMipmapLevels - 1);
+#endif
 
 	if (texinfo.glTarget == GL_TEXTURE_CUBE_MAP) {
 		texinfo.glTarget = GL_TEXTURE_CUBE_MAP_POSITIVE_X;


### PR DESCRIPTION
Setting GL_TEXTURE_MAX_LEVEL allows a texture with a partial mipmap chain to be complete regardless of filtering mode.

Should it use glTexStorage instead if available?

What should happen on ES1/2?