### PR TITLE
Fix dependency for toktx. Name needs to be cmake name of library

### DIFF
--- a/build/cmake/CMakeLists.txt
+++ b/build/cmake/CMakeLists.txt
@@ -78,5 +78,5 @@ include_directories(${DEPTH}/include)
 add_subdirectory(libktx libktx)
 add_subdirectory(toktx toktx)
 
-add_dependencies(toktx libktx)
+add_dependencies(toktx ktx)
 


### PR DESCRIPTION
This spawns a warning in cmake 3.0