### PR TITLE
Fix reserved identifier violations

### DIFF
--- a/include/ktx.h
+++ b/include/ktx.h
@@ -1,8 +1,8 @@
 /* -*- tab-width: 4; -*- */
 /* vi: set sw=2 ts=4: */
 
-#ifndef _KTX_H_
-#define _KTX_H_
+#ifndef KTX_H_A55A6F00956F42F3A137C11929827FE1
+#define KTX_H_A55A6F00956F42F3A137C11929827FE1
 
 /**
  * @file


### PR DESCRIPTION
An identifier [does not fit](https://www.securecoding.cert.org/confluence/display/c/DCL37-C.+Do+not+declare+or+define+a+reserved+identifier#DCL37-C.Donotdeclareordefineareservedidentifier-NoncompliantCodeExample%28HeaderGuard%29 "Do not use identifiers that are reserved for the compiler implementation.") to the expected naming convention for the programming languages "C" and "C++". It can be renamed.

The probability for name clashes can also be reduced especially for include guards by the addition of an universally unique identifier.